### PR TITLE
Configurable entry metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ mocha.reporter(StackdriverReporter, {
   projectId: "myGcpProjectId",
   logName: "myLogName",
   alsoConsole: false // (optional) if true, also output result to console
+  onlyConsole: false // (optional) if true, only output result to console
 });
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@ Mocha reporter using the Google Cloud Logging API.
 
 ## CLI
 
-`mocha --reporter mocha-stackdriver-reporter --reporter-options projectId=myGcpProjectId,logName=myLogName`
+Run mocha with reporter configured:
+
+```bash
+mocha --reporter mocha-stackdriver-reporter --reporter-options projectId=myGcpProjectId,logName=myLogName
+```
+
+Entry metadata can be set with environment variable `ENTRY_METADATA`:
+
+```bash
+ENTRY_METADATA='{ "resource": { "labels": { "function_name": "my-cloud-function", "project_id": "my-project-id", "region": "my-region" }, "type": "cloud_function" } }' \
+mocha --reporter mocha-stackdriver-reporter --reporter-options projectId=my-project-id,logName=my-log-name
+```
 
 ## Code
 
@@ -18,12 +29,22 @@ Mocha reporter using the Google Cloud Logging API.
 const Mocha = require("mocha");
 const StackdriverReporter = require("mocha-stackdriver-reporter");
 
-const mocha = new Mocha());
+const mocha = new Mocha();
 
 mocha.reporter(StackdriverReporter, {
-  projectId: "myGcpProjectId",
-  logName: "myLogName",
-  alsoConsole: false // (optional) if true, also output result to console
-  onlyConsole: false // (optional) if true, only output result to console
+  projectId: "my-project-id",
+  logName: "my-log-name",
+  entryMetadata: {
+    resource: {
+      labels: {
+        function_name: "my-cloud-function",
+        project_id: "my-project-id",
+        region: "my-region",
+      },
+      type: "cloud_function",
+    },
+  },
+  alsoConsole: false, // (optional) if true, also output result to console
+  onlyConsole: false, // (optional) if true, only output result to console
 });
 ```

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mocha": "^6"
   },
   "scripts": {
-    "test": "mocha test/*-tests.js --reporter min"
+    "test": "mocha test/*-tests.js --reporter min",
+    "dryrun": "mocha test/*-tests.js --reporter index.js"
   }
 }

--- a/src/google-cloud-logger.js
+++ b/src/google-cloud-logger.js
@@ -2,9 +2,13 @@
 const { Logging } = require("@google-cloud/logging");
 
 class CloudLogger {
-  constructor(projectId, logName) {
+  constructor(projectId, logName, metadata) {
+
     // Creates a client
     const logging = new Logging({ projectId });
+
+    // Metadata for entry
+    this.metadata = metadata;
 
     // Selects the log to write to
     this.log = logging.log(logName);
@@ -12,7 +16,7 @@ class CloudLogger {
 
   async info(message) {
     // Prepares a log entry
-    const entry = this.log.entry(message);
+    const entry = this._createEntry(message);
 
     // Writes the log entry
     await this.log.info(entry);
@@ -20,10 +24,16 @@ class CloudLogger {
 
   async error(message) {
     // Prepares a log entry
-    const entry = this.log.entry(message);
+    const entry = this._createEntry(message);
 
     // Writes the log entry
     await this.log.error(entry);
+  }
+
+  _createEntry(message) {
+    return !!this.metadata
+      ? this.log.entry(this.metadata, message)
+      : this.log.entry(message);
   }
 }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -73,9 +73,9 @@ Example: --reporter-options projectId=myGcpProjectId,logName=myLog
 }
 
 function getEntryMetadata(reporterOptions) {
-  if (!reporterOptions["entry-metadata"]) return undefined;
+  if (!reporterOptions.entryMetadata) return undefined;
 
-  const entryMetadata = reporterOptions["entry-metadata"];
+  const entryMetadata = reporterOptions.entryMetadata;
 
   if (typeof entryMetadata === "string") {
     return JSON.parse(entryMetadata);
@@ -83,7 +83,7 @@ function getEntryMetadata(reporterOptions) {
     return entryMetadata;
   } else {
     const errorMessage = `
-Reporter option 'entry-metadata' cannot be parsed to JSON.
+Reporter option 'entryMetadata' cannot be parsed to JSON.
 Please, specify metadata for entry as JSON or object literal.
 `;
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -31,11 +31,13 @@ function StackdriverReporter(runner, options = {}) {
       });
     })
     .once(EVENT_RUN_END, () => {
+      if (reporterOptions.alsoConsole || reporterOptions.onlyConsole)
+        console.log("result", JSON.stringify(result));
+
+      if (!reporterOptions.onlyConsole) {
       if (result.failures.length > 0) log.error(result);
       else log.info(result);
-
-      if (reporterOptions.alsoConsole)
-        console.log("result", JSON.stringify(result));
+      }
     });
 }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -13,6 +13,7 @@ function StackdriverReporter(runner, options = {}) {
   const { reporterOptions } = options;
   const { projectId, logName } = ensureOptions(reporterOptions);
 
+  Mocha.reporters.Base.call(this, runner, options);
   const log = new CloudLogger(projectId, logName);
 
   const result = {
@@ -64,5 +65,8 @@ Example: --reporter-options projectId=myGcpProjectId,logName=myLog
     logName,
   };
 }
+
+
+Mocha.utils.inherits(StackdriverReporter, Mocha.reporters.Base);
 
 module.exports = StackdriverReporter;

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -73,9 +73,10 @@ Example: --reporter-options projectId=myGcpProjectId,logName=myLog
 }
 
 function getEntryMetadata(reporterOptions) {
-  if (!reporterOptions.entryMetadata) return undefined;
+  const entryMetadata =
+    reporterOptions.entryMetadata || process.env.ENTRY_METADATA;
 
-  const entryMetadata = reporterOptions.entryMetadata;
+  if (!entryMetadata) return undefined;
 
   if (typeof entryMetadata === "string") {
     return JSON.parse(entryMetadata);
@@ -84,6 +85,8 @@ function getEntryMetadata(reporterOptions) {
   } else {
     const errorMessage = `
 Reporter option 'entryMetadata' cannot be parsed to JSON.
+Current configuration:
+entryMetadata => ${entryMetadata}
 Please, specify metadata for entry as JSON or object literal.
 `;
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -77,9 +77,10 @@ function getEntryMetadata(reporterOptions) {
 
   const entryMetadata = reporterOptions["entry-metadata"];
 
-  if (typeof entryMetadata === "string" || typeof entryMetadata === "object") {
-    if (typeof entryMetadata === "string") return JSON.parse(entryMetadata);
-    else return entryMetadata;
+  if (typeof entryMetadata === "string") {
+    return JSON.parse(entryMetadata);
+  } else if (typeof entryMetadata === "object") {
+    return entryMetadata;
   } else {
     const errorMessage = `
 Reporter option 'entry-metadata' cannot be parsed to JSON.

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -44,6 +44,10 @@ function StackdriverReporter(runner, options = {}) {
     });
 }
 
+Mocha.utils.inherits(StackdriverReporter, Mocha.reporters.Base);
+
+module.exports = StackdriverReporter;
+
 function ensureOptions(reporterOptions) {
   if (
     !reporterOptions ||
@@ -86,7 +90,3 @@ Please, specify metadata for entry as JSON or object literal.
     throw new Error(errorMessage);
   }
 }
-
-Mocha.utils.inherits(StackdriverReporter, Mocha.reporters.Base);
-
-module.exports = StackdriverReporter;

--- a/test/reporter-tests.js
+++ b/test/reporter-tests.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const Mocha = require("mocha");
 
 const StackdriverReporter = require("../");
 
@@ -7,6 +8,72 @@ describe("StackdriverReporter", function () {
     assert.throws(
       StackdriverReporter,
       /projectId=myGcpProjectId,logName=myLog/
+    );
+  });
+
+  it("can specify entry metadata as object literal", (done) => {
+    const options = {
+      reporterOptions: {
+        onlyConsole: true,
+        projectId: "my-project",
+        logName: "my-log",
+        "entry-metadata": {
+          resource: {
+            labels: {
+              function_name: "my-cloud-function",
+              project_id: "my-project",
+              region: "my-region",
+            },
+            type: "cloud_function",
+          },
+        },
+      },
+    };
+
+    const runner = new Mocha().run(done);
+
+    new StackdriverReporter(runner, options);
+  });
+
+  it("can specify entry metadata as JSON", (done) => {
+    const entryMetadata = JSON.stringify({
+      resource: {
+        labels: {
+          function_name: "my-cloud-function",
+          project_id: "my-project",
+          region: "my-region",
+        },
+        type: "cloud_function",
+      },
+    });
+
+    const options = {
+      reporterOptions: {
+        onlyConsole: true,
+        projectId: "my-project",
+        logName: "my-log",
+        "entry-metadata": entryMetadata,
+      },
+    };
+
+    const runner = new Mocha().run(done);
+
+    new StackdriverReporter(runner, options);
+  });
+
+  it("entry metadata required as JSON like format", (done) => {
+    const options = {
+      reporterOptions: {
+        projectId: "my-project",
+        logName: "my-log",
+        "entry-metadata": 666,
+      },
+    };
+
+    const runner = new Mocha().run(done);
+    assert.throws(
+      () => new StackdriverReporter(runner, options),
+      /Reporter option 'entry-metadata' cannot be parsed to JSON/
     );
   });
 });

--- a/test/reporter-tests.js
+++ b/test/reporter-tests.js
@@ -4,6 +4,14 @@ const Mocha = require("mocha");
 const StackdriverReporter = require("../");
 
 describe("StackdriverReporter", function () {
+  beforeEach(function () {
+    delete process.env.ENTRY_METADATA;
+  });
+
+  afterEach(function () {
+    delete process.env.ENTRY_METADATA;
+  });
+
   it("projectId and logName options required", function () {
     assert.throws(
       StackdriverReporter,
@@ -53,6 +61,33 @@ describe("StackdriverReporter", function () {
         projectId: "my-project",
         logName: "my-log",
         entryMetadata,
+      },
+    };
+
+    const runner = new Mocha().run(done);
+
+    new StackdriverReporter(runner, options);
+  });
+
+  it("specify entry metadata as environment variable", (done) => {
+    const entryMetadata = JSON.stringify({
+      resource: {
+        labels: {
+          function_name: "my-cloud-function",
+          project_id: "my-project",
+          region: "my-region",
+        },
+        type: "cloud_function",
+      },
+    });
+
+    process.env.ENTRY_METADATA = entryMetadata;
+
+    const options = {
+      reporterOptions: {
+        onlyConsole: true,
+        projectId: "my-project",
+        logName: "my-log",
       },
     };
 

--- a/test/reporter-tests.js
+++ b/test/reporter-tests.js
@@ -17,7 +17,7 @@ describe("StackdriverReporter", function () {
         onlyConsole: true,
         projectId: "my-project",
         logName: "my-log",
-        "entry-metadata": {
+        entryMetadata: {
           resource: {
             labels: {
               function_name: "my-cloud-function",
@@ -52,7 +52,7 @@ describe("StackdriverReporter", function () {
         onlyConsole: true,
         projectId: "my-project",
         logName: "my-log",
-        "entry-metadata": entryMetadata,
+        entryMetadata,
       },
     };
 
@@ -66,14 +66,14 @@ describe("StackdriverReporter", function () {
       reporterOptions: {
         projectId: "my-project",
         logName: "my-log",
-        "entry-metadata": 666,
+        entryMetadata: 666,
       },
     };
 
     const runner = new Mocha().run(done);
     assert.throws(
       () => new StackdriverReporter(runner, options),
-      /Reporter option 'entry-metadata' cannot be parsed to JSON/
+      /Reporter option 'entryMetadata' cannot be parsed to JSON/
     );
   });
 });


### PR DESCRIPTION
Fixes #1: Option to set entry metadata either with env variable or via reporter options.

As examples where added, at the same time fixed #3.