### PR TITLE
Use min engine version in test runs

### DIFF
--- a/.github/workflows/npm-cit.yml
+++ b/.github/workflows/npm-cit.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [10.12.0]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Run tests with required Node.js version of Mocha 8.